### PR TITLE
feat: add Docker-based Zabbix test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# ABOUTME: Git ignore patterns for Go and Terraform provider development.
+# ABOUTME: Excludes build artifacts, IDE files, and test outputs.
+
+# Go build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+
+# Go workspace
+go.work
+go.work.sum
+
+# Dependency directories
+vendor/
+
+# Build output
+bin/
+dist/
+
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfplan
+.terraform/
+.terraform.lock.hcl
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test output
+coverage.out
+coverage.html
+
+# Local environment
+.env
+.envrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,45 @@
+# ABOUTME: Documentation for the local Zabbix test environment.
+# ABOUTME: Explains how to start the stack and access the API.
+
+# Zabbix Test Environment
+
+Local Zabbix 7.0 stack for running acceptance tests.
+
+## Quick Start
+
+```bash
+# Start the stack
+docker compose up -d
+
+# Wait for services to be healthy
+docker compose ps
+
+# Stop the stack
+docker compose down
+
+# Stop and remove all data
+docker compose down -v
+```
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| postgres | 5432 (internal) | PostgreSQL 16 database |
+| zabbix-server | 10051 (internal) | Zabbix Server |
+| zabbix-web | 8080 | Web UI and API endpoint |
+
+## API Access
+
+- **URL**: `http://localhost:8080/api_jsonrpc.php`
+- **Default credentials**: Admin / zabbix
+- **Pre-configured API token**: `071fb9d2e8f72cf9c40128f0f5aab3def1bab0893413314b083fdcb4551eb01a`
+
+The API token is automatically created by the `db-init` service when starting fresh.
+
+## Environment Variables for Tests
+
+```bash
+export ZABBIX_URL="http://localhost:8080/api_jsonrpc.php"
+export ZABBIX_API_TOKEN="071fb9d2e8f72cf9c40128f0f5aab3def1bab0893413314b083fdcb4551eb01a"
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,72 @@
+# ABOUTME: Docker Compose configuration for local Zabbix test environment.
+# ABOUTME: Provides a complete Zabbix 7.0 stack for running acceptance tests.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U zabbix"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  zabbix-server:
+    image: zabbix/zabbix-server-pgsql:alpine-7.0-latest
+    environment:
+      DB_SERVER_HOST: postgres
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "zabbix_server", "-R", "config_cache_reload"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  zabbix-web:
+    image: zabbix/zabbix-web-nginx-pgsql:alpine-7.0-latest
+    ports:
+      - "8080:8080"
+    environment:
+      ZBX_SERVER_HOST: zabbix-server
+      DB_SERVER_HOST: postgres
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+      PHP_TZ: UTC
+    depends_on:
+      zabbix-server:
+        condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"apiinfo.version\",\"params\":{},\"id\":1}' http://localhost:8080/api_jsonrpc.php | grep -q result"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  db-init:
+    image: postgres:16-alpine
+    volumes:
+      - ./init-db.sql:/init-db.sql:ro
+    environment:
+      PGPASSWORD: zabbix
+    depends_on:
+      zabbix-server:
+        condition: service_healthy
+    command: ["psql", "-h", "postgres", "-U", "zabbix", "-d", "zabbix", "-f", "/init-db.sql"]
+    restart: "no"
+
+volumes:
+  postgres-data:

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -1,0 +1,8 @@
+-- ABOUTME: Database initialization script for test environment.
+-- ABOUTME: Creates a static API token for acceptance tests.
+
+-- Insert API token for CI/CD testing
+-- Token value: 071fb9d2e8f72cf9c40128f0f5aab3def1bab0893413314b083fdcb4551eb01a
+INSERT INTO public.token (tokenid, name, description, userid, token, lastaccess, status, expires_at, created_at, creator_userid)
+VALUES (1, 'cicd', 'CI/CD', 1, '4b99fc440dabdd5b3dca02b16c1a5a705f01fd25d1a8f7ef0743cd9029499ebe09d179bba2bd3408919de75d0f60330b323d7838b65f979e5bb59382577d7a83', 0, 0, 0, 1766783844, 1)
+ON CONFLICT (tokenid) DO NOTHING;


### PR DESCRIPTION
## Summary

- Add local Zabbix 7.0 stack for running acceptance tests with TDD approach
- Pre-configured API token for automated testing
- Health checks ensuring all services are ready before tests run

## Components

- PostgreSQL 16 database
- Zabbix Server 7.0
- Zabbix Web (nginx) with API endpoint at `http://localhost:8080/api_jsonrpc.php`
- Database initialization with static API token

## Test plan

- [x] `docker compose up -d` brings up all services
- [x] All services report healthy status
- [x] API responds to authenticated requests with pre-configured token
- [x] Fresh start (with `-v` flag) properly reinitializes the token

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)