### PR TITLE
fix: add pinentry-mode loopback for GPG signing in CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,8 @@ signs:
       - "--output"
       - "${signature}"
       - "--detach-sign"
+      - "--pinentry-mode"
+      - "loopback"
       - "${artifact}"
 
 release:


### PR DESCRIPTION
## Summary
- Fixes GPG signing failure in release workflow ("Inappropriate ioctl for device")
- Adds `--pinentry-mode loopback` to goreleaser GPG signing args to prevent TTY prompts in CI

## Test plan
- [ ] Merge PR and verify release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)