### PR TITLE
fix: pass GPG passphrase via stdin for signing in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,9 +50,10 @@ signs:
       - "--output"
       - "${signature}"
       - "--detach-sign"
-      - "--pinentry-mode"
-      - "loopback"
+      - "--passphrase-fd"
+      - "0"
       - "${artifact}"
+    stdin: "{{ .Env.GPG_PASSPHRASE }}"
 
 release:
   extra_files:


### PR DESCRIPTION
## Summary
- Fixes GPG signing failure in release workflow ("gpg: Sorry, we are in batchmode - can't get input")
- Changed from `--pinentry-mode loopback` to `--passphrase-fd 0` with goreleaser's `stdin` option
- Passes `GPG_PASSPHRASE` environment variable to goreleaser

## Test plan
- [ ] Merge PR and verify release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)