### PR TITLE
fix: handle non-version-bumping commits gracefully in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           token: ${{ github.token }}
           branch: main
+          noVersionBumpBehavior: current
 
       - name: Check if release needed
         id: check


### PR DESCRIPTION
## Summary

- Sets `noVersionBumpBehavior: current` on the semver-action so it returns the current version instead of failing when no version-bumping commits are found
- The existing "Check if release needed" step will then skip the release gracefully

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)